### PR TITLE
Makes the not-zen version more zen

### DIFF
--- a/staticfiles/staila.css
+++ b/staticfiles/staila.css
@@ -9,7 +9,7 @@ h2{
 }
 
 #container{
-	width: 50%;
+	width: 90%;
 	text-align: left;
 	margin: 0 auto;
 	color: #576E74;


### PR DESCRIPTION
This is the first thing that I normally edit in chrome with the "inspect" feature: change the page's width to 90% rather than 50%, else the website is unusable. By the way, there is also two errors in your twitter link about "Report or Sugest a feature", try clicking it. "Suggest" should take two "g" and the link is broken.